### PR TITLE
WIP RgbdSensor -> CameraArray: Initial high-level changes

### DIFF
--- a/attic/systems/sensors/rgbd_camera.h
+++ b/attic/systems/sensors/rgbd_camera.h
@@ -24,6 +24,10 @@ namespace sensors {
 /// An RGB-D camera system that provides RGB, depth and label images using
 /// visual elements of RigidBodyTree.
 ///
+/// @warning This is an old interface, with potentially ambiguous and outdated
+/// terms. Please see `RgbdSensor` and `CameraInfo` for more modern
+/// terminology.
+///
 /// Let `W` be the world coordinate system. In addition to `W`, there are three
 /// more coordinate systems that are associated with an RgbdCamera. They are
 /// defined as follows:

--- a/geometry/render/camera_properties.h
+++ b/geometry/render/camera_properties.h
@@ -10,6 +10,10 @@ namespace render {
 
 // TODO(SeanCurtis-TRI): Allow for configuring the intrinsic matrix directly
 // with a projection matrix.
+// TODO(eric.cousineau): Make this have `CameraInfo` as a member, move that
+// class outside of `drake::systems`, and possibly rename this class, in order
+// to decouple generic pinhole parameters from Drake-specific render engine
+// information.
 /** The intrinsic properties for a render camera. The render system
  uses a reduced set of intrinsic parameters by making some simplifying
  assumptions:

--- a/systems/sensors/camera_info.cc
+++ b/systems/sensors/camera_info.cc
@@ -25,6 +25,13 @@ CameraInfo::CameraInfo(int width, int height, double vertical_fov_rad)
                  height * 0.5 / std::tan(0.5 * vertical_fov_rad),
                  height * 0.5 / std::tan(0.5 * vertical_fov_rad),
                  width * 0.5 - 0.5, height * 0.5 - 0.5) {}
+// TODO(SeanCurtis-TRI): The shift of the principal point by (-0.5, -0.5) is
+//  overly opaque. The primary explanation comes from pixel addressing
+//  conventions used in various APIs (see
+//  https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_fragment_coord_conventions.txt
+//  However, we don't want to look like this class is coupled with OpenGL. How
+//  do we articulate this math in a way that *doesn't* depend on OpenGL?
+//  See https://github.com/SeanCurtis-TRI/drake/pull/5#pullrequestreview-264447958.
 
 }  // namespace sensors
 }  // namespace systems

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -19,51 +19,51 @@ Please note the following terms:
 - frame, pose: denotes an origin and a space-spanning basis in 2D/3D, as in
   @ref multibody_frames_and_bodies. Unless otherwise stated, any described
   frame implies this definition.
-- video frame: an image in a video sequence. This is *not* an extension of
-  "frame" as a general term.
 - sensor: a device used to take and report measurements.
-- image: an array of measurements. Coordinates are in pixels.
-- imager: a sensor that measures images.
-- camera: an image sensor.
+- image: an array of measurements. Coordinates are in typically in pixels.
+- imager: a sensor whose measurements are reported in images.
+- camera: an image sensor using lenses and photoreceptive surfaces.
 - aperature: a hole through which light travels through.
-- image plane: defines how the 3D world is projected to a 2D image. In
-  accordance with the OpenCV documentation below, the image plane will be
-  presented as though it were "in front" of the aperature, rather than behind
-  (which requires accounting for the camera obscura effect).
+- image plane: defined by the lens and aperature and captures how the 3D world
+  is projected to a 2D image.
 - pinhole camera: a physical camera with no lens and a tiny aperature.
-- pinhole model: modeling a camera as though it were a pinhole camera, with
-  parameters that account for the camera lens and image plane. In Drake, all
-  cameras are assumed to use the pinhole model unless otherwise stated. The
-  images captured by these cameras are 2D, and their pixel coordinates are
-  described as `(u, v)`.
-- viewing direction / optical axis: direction from aperature towards scene being
-  captured by the camera (orthogonal to the image plane for the pinhole model).
-- principal point, camera center: the intersection of the viewing ray with the
-  image plane, typically measured in pixels.
+- viewing raw: ray from aperature towards scene being captured by the camera
+  (orthogonal to the image plane for the pinhole model). In other words, it's
+  the way the camera is facing.
+- principal point: the intersection of the viewing ray with the image plane,
+  typically measured in pixels.
 
-The camera frame C is comprised of the basis [Cx Cy Cz] and origin point Co,
-which are described as follows:
+In Drake, all cameras are assumed to be modeled as a pinhole camera (using the
+"pinhole model") unless otherwise stated. As in the
+[OpenCV documentation](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html),
+the model's image plane will be used rather than pinhole camera's; i.e. it is
+presented as in front of the aperature, rather than behind.
 
-- Co at camera aperature (per the pinhole model)
-- Cz aligned with the optical axis (orthogonal to the image plane).
+Any given camera measures a captured image, which is 2D with pixel coordinates
+defined as `(u, v)`. The camera frame is located at frame C which is comprised
+of the basis [Cx Cy Cz] and origin point Co, which are defined as follows:
+
+- Co at camera aperature.
+- Cz aligned with the viewing ray (orthogonal to the image plane).
 - Cx aligned with the `u` axis of the captured image.
 - Cy aligned with the `v` axis of the captured image.
 
 This can be summarized as `X-right`, `Y-down`, and `Z-forward` with respect to
 the image plane / captured image when visualized in 3D w.r.t. the camera frame.
 
-The projection from coordinates `(X, Y, Z)`, in meters `m`, in the camera frame
-C to image coordinates `(u, v)`, in pixels, can be described as:
+The projection from coordinates `(X, Y, Z)`, in meters, in the camera frame C
+to image coordinates `(u, v)`, in pixels, is defined as:
 <pre>
-  u = focal_x * (X/Z) + center_x
-  v = focal_y * (Y/Z) + center_y
+  u = focal_x * (X/Z) + ppx
+  v = focal_y * (Y/Z) + ppy
 </pre>
-where `focal_x, focal_y` are the focal lengths, in `pixels / (m / m)`, and
-`center_x, center_y`, in pixels, describe the camera center (or principal
-point).
+where `focal_x, focal_y`, in `pixels / (m / m)`, are the focal lengths and
+`ppx, ppy`, in pixels, describe the principal point.
 
-For more detail including an explanation of the focal lengths, refer to:
-- http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
+Footnotes:
+
+-  A "video frame" should be considered an image in a video sequence, *not* an
+  extension of "frame" as a general term.
 */
 class CameraInfo final {
  public:
@@ -76,10 +76,8 @@ class CameraInfo final {
    @param height The image height in pixels, must be greater than zero.
    @param focal_x The focal length x in pixels.
    @param focal_y The focal length y in pixels.
-   @param center_x The x coordinate of the image center in the pixel
-   coordinate system in pixels.
-   @param center_y The y coordinate of the image center in the pixel
-   coordinate system in pixels.
+   @param center_x The x coordinate of the principal point in pixels.
+   @param center_y The y coordinate of the principal point in pixels.
   */
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y);
@@ -119,10 +117,13 @@ class CameraInfo final {
   /** Returns the focal length y in pixels. */
   double focal_y() const { return intrinsic_matrix_(1, 1); }
 
-  /** Returns the image center x value in pixels. */
+  // TODO(eric.cousineau): Deprecate "center_{x,y}" and use
+  // "principal_point_{x,y}" or "pp{x,y}".
+
+  /** Returns the principal point's x coordinate in pixels. */
   double center_x() const { return intrinsic_matrix_(0, 2); }
 
-  /** Returns the image center y value in pixels. */
+  /** Returns the principal point's y coordinate in pixels. */
   double center_y() const { return intrinsic_matrix_(1, 2); }
 
   /** Returns the camera intrinsic matrix. */

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -107,8 +107,8 @@ namespace sensors {
  - __image frame__: the 2D frame embedded in 3D space spanning the image plane.
    The image frame's x- and y-axes are parallel with `Cx` and `Cy`,
    respectively. Coordinates are expressed as the pair `(u, v)` and the camera's
-   image lies on the plane spanned by the frame's basis, entirely in the first
-   quadrant (i.e, `u ≥ 0` and `v ≥ 0`).
+   image lies on the plane spanned by the frame's basis. The _center_ of the
+   pixel in the first row and first column is at `(u=0, v=0)`.
  - __image plane__: a plane in 3D which is perpendicular to the camera's viewing
    direction. Conceptually, the image lies on this plane.
      - In a physical pinhole camera, the aperture is between the image plane and
@@ -150,8 +150,8 @@ class CameraInfo final {
   /**
    Constructs this instance from image size and vertical field of view. We
    assume the principal point is in the center of the image;
-   `(center x, center_y)` is equal to `(width / 2 - 0.5, height / 2 - 0.5)`. We
-   also assume the focal lengths `focal_x` and `focal_y` are identical
+   `(center x, center_y)` is equal to `(width / 2.0 - 0.5, height / 2.0 - 0.5)`.
+   We also assume the focal lengths `focal_x` and `focal_y` are identical
    (modeling a radially symmetric lens). The value is derived from field of
    view and image size as:
 

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -8,111 +8,110 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-/// Simple data structure for camera information that includes the image size
-/// and camera intrinsic parameters.
-///
-/// To clarify the terminology used to describe 2D and/or 3D spaces throughout
-/// the class, we use "coordinate system" rather than "frame".  This is because
-/// the term "frame" has two different meanings in the computer vision field: a
-/// synonym of coordinate system, and a snapshot out of consecutively captured
-/// images.  To ensure the reader will not be confused, we clearly differentiate
-/// the use of the terms "coordinate system" and "frame" by using "coordinate
-/// system" to denote 2D/3D spaces and "frame" to denote a captured image.
-///
-/// There are three types of the coordinate systems that are relevant to this
-/// class:
-///
-///   - the camera coordinate system
-///   - the image coordinate system
-///   - the pixel coordinate system.
-///
-/// The camera coordinate system expresses a camera's 6D pose relative to the
-/// world coordinate system.  The camera coordinate system is defined to be
-/// `X-right`, `Y-down` and `Z-forward`.  The `Z` axis is also called the
-/// "optical axis".  Note that each axis in the camera coordinate system is
-/// expressed in the upper case, like `(X, Y, Z)` to distinguish from those of
-/// the image coordinate system which we explain next.
-///
-/// The image coordinate system is the 2D coordinate system made by projecting
-/// the camera coordinate system onto the 2D image plane which is perpendicular
-/// to the "optical axis".  Therefore, the direction of the each axis is
-/// `x-right` and `y-down`, and the origin of the image coordinate system is
-/// located at the crossing point between the 2D image plane and the "optical
-/// axis".  This origin is called the "image center" or "principal point".  Note
-/// that each axis in the image coordinate system is expressed in the lower case
-/// , like `(x, y)`.
-///
-/// The pixel coordinate system is also a 2D coordinate system.  The main
-/// differences between the pixel coordinate system and the image coordinate
-/// system are the location of the origin and the direction of the axes.  The
-/// origin of the pixel coordinate system is at the left-upper corner of the
-/// image and the direction of the each axis is the same as those of the image
-/// coordinate system.  The axes of the pixel coordinate system are expressed
-/// using `u` and `v`, therefore the axes directions are `u-right` and `v-down`.
-///
-/// For more detail including an explanation of the focal lengths, refer to:
-/// http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
-/// and https://en.wikipedia.org/wiki/Pinhole_camera_model.
-///
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
+/**
+Simple data structure for camera information that includes the image size
+and camera intrinsic parameters.
+
+Please note the following terms:
+
+- frame, pose: denotes an origin and a space-spanning basis in 2D/3D, as in
+  @ref multibody_frames_and_bodies.
+- video frame: an image in a video sequence.
+- camera: an image sensor with lens; in Drake, this will be modeled as a
+  pinhole cameras unless stated otherwise. Because of this, the camera
+  aperature is a point in space.
+- image plane: defines how the 3D world is projected to a 2D image.
+
+The camera frame `C` is comprised of the basis [Cx Cy Cz] and origin point Co,
+which are described as follows:
+
+- Co at camera aperature.
+- Cz aligned with the viewing direction, orthogonal to the image plane.
+- Cx aligned with the right direction of the image plane.
+- Cy aligned with the downwards direction of the image plane.
+
+This can be summarized as `X-right`, `Y-down`, and `Z-forward` with respect to
+the image plane.
+
+The image plane can be described in the following coordinate systems:
+
+- normalized coordinate system `(X/Z, Y/Z)`, with its origin at the principal
+  point.
+- pixel coordinate system `(u, v)` using the following transformation:
+  <pre>
+    u = focal_x * (X/Z) + center_x
+    v = focal_y * (Y/Z) + center_y
+  </pre>
+  where `focal_x, focal_y` are focal lengths, and `center_x, center_y` describe
+  the principal point.
+
+For more detail including an explanation of the focal lengths, refer to:
+- https://en.wikipedia.org/wiki/Pinhole_camera_model
+- http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
+*/
 class CameraInfo final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CameraInfo)
 
-  /// Constructor that directly sets the image size, center, and focal lengths.
-  ///
-  /// @param width The image width in pixels, must be greater than zero.
-  /// @param height The image height in pixels, must be greater than zero.
-  /// @param focal_x The focal length x in pixels.
-  /// @param focal_y The focal length y in pixels.
-  /// @param center_x The x coordinate of the image center in the pixel
-  /// coordinate system in pixels.
-  /// @param center_y The y coordinate of the image center in the pixel
-  /// coordinate system in pixels.
+  /**
+   Constructor that directly sets the image size, center, and focal lengths.
+
+   @param width The image width in pixels, must be greater than zero.
+   @param height The image height in pixels, must be greater than zero.
+   @param focal_x The focal length x in pixels.
+   @param focal_y The focal length y in pixels.
+   @param center_x The x coordinate of the image center in the pixel
+   coordinate system in pixels.
+   @param center_y The y coordinate of the image center in the pixel
+   coordinate system in pixels.
+  */
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y);
 
-  /// Constructor that sets the image size and vertical field of view `fov_y`.
-  /// We assume there is no image offset, so the image center `(center_x,`
-  /// `center_y)` is equal to `(width / 2, height / 2)`.  We also assume the
-  /// focal lengths `focal_x` and `focal_y` are identical.  The horizontal
-  /// field of view `fov_x` is calculated using the aspect ratio of the image
-  /// width and height together with the vertical field of view:
-  /// <pre>
-  ///   fov_x = 2 * atan(width / height * tan(fov_y / 2)).
-  /// </pre>
-  /// This can be derived from the equations of the focal lengths:
-  /// <pre>
-  ///   focal_x = width / 2 / tan(fov_x / 2)
-  ///   focal_y = height / 2 / tan(fov_y / 2)
-  /// </pre>
-  /// where `focal_x / focal_y = 1`.
-  ///
-  /// @param width The image width in pixels, must be greater than zero.
-  /// @param height The image height in pixels, must be greater than zero.
-  /// @param fov_y The vertical field of view.
+  /**
+   Constructor that sets the image size and vertical field of view `fov_y`.
+   We assume there is no image offset, so the image center `(center_x,`
+   `center_y)` is equal to `(width / 2, height / 2)`.  We also assume the
+   focal lengths `focal_x` and `focal_y` are identical.  The horizontal
+   field of view `fov_x` is calculated using the aspect ratio of the image
+   width and height together with the vertical field of view:
+   <pre>
+     fov_x = 2 * atan(width / height * tan(fov_y / 2)).
+   </pre>
+   This can be derived from the equations of the focal lengths:
+   <pre>
+     focal_x = width / 2 / tan(fov_x / 2)
+     focal_y = height / 2 / tan(fov_y / 2)
+   </pre>
+   where `focal_x / focal_y = 1`.
+
+   @param width The image width in pixels, must be greater than zero.
+   @param height The image height in pixels, must be greater than zero.
+   @param fov_y The vertical field of view.
+  */
   CameraInfo(int width, int height, double fov_y);
 
-  /// Returns the width of the image in pixels.
+  /** Returns the width of the image in pixels. */
   int width() const { return width_; }
 
-  /// Returns the height of the image in pixels.
+  /** Returns the height of the image in pixels. */
   int height() const { return height_; }
 
-  /// Returns the focal length x in pixels.
+  /** Returns the focal length x in pixels. */
   double focal_x() const { return intrinsic_matrix_(0, 0); }
 
-  /// Returns the focal length y in pixels.
+  /** Returns the focal length y in pixels. */
   double focal_y() const { return intrinsic_matrix_(1, 1); }
 
-  /// Returns the image center x value in pixels.
+  /** Returns the image center x value in pixels. */
   double center_x() const { return intrinsic_matrix_(0, 2); }
 
-  /// Returns the image center y value in pixels.
+  /** Returns the image center y value in pixels. */
   double center_y() const { return intrinsic_matrix_(1, 2); }
 
-  /// Returns the camera intrinsic matrix.
+  /** Returns the camera intrinsic matrix. */
   const Eigen::Matrix3d& intrinsic_matrix() const {
     return intrinsic_matrix_;
   }

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -11,97 +11,155 @@ namespace sensors {
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
 /**
-Simple data structure for camera information that includes the image size
-and camera intrinsic parameters.
+ Simple struct for characterizing the Drake camera model. The camera model is
+ based on the
+ [pinhole _model_](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html)
+ , which is related to but distinct from an actual
+ [pinhole _camera_](https://en.wikipedia.org/wiki/Pinhole_camera). The former
+ is a mathematical model for producing images, the latter is a physical object.
 
-Please note the following terms:
+ The camera info members are directly tied to the underlying model's
+ mathematical parameters. In order to understand the model parameters, we will
+ provide a discussion of how cameras are treated in Drake with some common
+ terminology (liberally borrowed from computer vision).
 
-- frame, pose: denotes an origin and a space-spanning basis in 2D/3D, as in
-  @ref multibody_frames_and_bodies. Unless otherwise stated, any described
-  frame implies this definition.
-- sensor: a device used to take and report measurements.
-- image: an array of measurements. Coordinates are in typically in pixels.
-- imager: a sensor whose measurements are reported in images.
-- camera: an image sensor using lenses and photoreceptive surfaces.
-- aperature: a hole through which light travels through.
-- image plane: defined by the lens and aperature and captures how the 3D world
-  is projected to a 2D image.
-- pinhole camera: a physical camera with no lens and a tiny aperature.
-- viewing raw: ray from aperature towards scene being captured by the camera
-  (orthogonal to the image plane for the pinhole model). In other words, it's
-  the way the camera is facing.
-- principal point: the intersection of the viewing ray with the image plane,
-  typically measured in pixels.
+ <h3>Pinhole camera model</h3>
 
-In Drake, all cameras are assumed to be modeled as a pinhole camera (using the
-"pinhole model") unless otherwise stated. As in the
-[OpenCV documentation](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html),
-the model's image plane will be used rather than pinhole camera's; i.e. it is
-presented as in front of the aperature, rather than behind.
+ (To get an exact definition of the terms used here, please refer to the
+ glossary below.)
 
-Any given camera measures a captured image, which is 2D with pixel coordinates
-defined as `(u, v)`. The camera frame is located at frame C which is comprised
-of the basis [Cx Cy Cz] and origin point Co, which are defined as follows:
+ Intuitively, a camera produces images of an observed environment. The pinhole
+ model serves as a camera for a virtually modeled environment. Its parameters
+ are those required to determine where in the resultant image a virtual object
+ appears. In essence, the parameters of the camera model define a mapping from
+ points in 3D space to a point on the image (2D space).
 
-- Co at camera aperature.
-- Cz aligned with the viewing ray (orthogonal to the image plane).
-- Cx aligned with the `u` axis of the captured image.
-- Cy aligned with the `v` axis of the captured image.
+ The full discussion of this mapping can be found in the
+ [OpenCV documentation](https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html).
+ Here, we'll highlight one or two points as it relates to this struct.
 
-This can be summarized as `X-right`, `Y-down`, and `Z-forward` with respect to
-the image plane / captured image when visualized in 3D w.r.t. the camera frame.
+ The mapping from 3D to 2D is decomposed into two sets of properties: extrinsic
+ and intrinsic. The extrinsic properties define the pose of the camera in the
+ environment -- specifically, given the camera frame `C`, it defines `X_WC`.
+ Once a point `Q` is measured and expressed in the camera's frame (i.e.,
+ `p_CQ_C`), the intrinsic matrix projects it into the 2D image. %CameraInfo does
+ _not_ concern itself with the extrinsic properties (other classes are
+ responsible for that -- see RgbdSensor).
 
-The projection from coordinates `(X, Y, Z)`, in meters, in the camera frame C
-to image coordinates `(u, v)`, in pixels, is defined as:
-<pre>
-  u = focal_x * (X/Z) + ppx
-  v = focal_y * (Y/Z) + ppy
-</pre>
-where `focal_x, focal_y`, in `pixels / (m / m)`, are the focal lengths and
-`ppx, ppy`, in pixels, describe the principal point.
+ %CameraInfo defines the parameters of the intrinsic projection. The projection
+ can be captured by the camera or intrinsic matrix which essentially maps points
+ in the camera frame C to the image plane (the matrix is called `A` in the
+ OpenCV documentation, but typically called `K` in computer vision literature):
 
-Footnotes:
+         │ f_x  0    c_x │
+     K = │ 0    f_y  c_y │, i.e.,
+         │ 0    0    1   │
 
--  A "video frame" should be considered an image in a video sequence, *not* an
-  extension of "frame" as a general term.
+ - This matrix maps a point in the camera frame C to the projective space of the
+   image (via homogeneous coordinates). The resulting image coordinate `(u, v)`
+   is extracted by dividing out the homogeneous scale factor.
+ - (c_x, c_y) defines the principal point.
+ - (f_x, f_y) defines the model focal length.
+
+ In other words, for point Q in the world frame, its texture coordinates
+ `(u_q, v_q)` are calculated as:
+
+      │ u_q │
+     s│ v_q │ = K ⋅ X_CW ⋅ p_WQ
+      │  1  │
+
+ Note: The expression on the right will generally produce a homogeneous
+ coordinate vector of the form `(s * u_q, s * v_q, s)`. The texture coordinate
+ is defined as the first two measures when the *third* measure is 1. The magic
+ of homogeneous coordinates allows us to simply factor out `s`.
+
+ <h3>Glossary</h3>
+
+ These terms are important to the discussion. Some refer to real world concepts
+ and some to the model. The application domain of the term will be indicated
+ and, where necessary, ambiguities will be resolved. The terms are ordered
+ alphabetically for ease of reference.
+
+ - __aperture__: the opening in a camera through which light passes. The origin
+   of the camera frame `Co` is located at the aperture's center.
+   - in a physical camera it may contain a lens and the size of the camera
+     affects optical artifacts such as depth of field.
+   - in the pinhole model, there is no lens and the aperture is a single point.
+ - __focal length__: a camera property that determines the field of view angle
+   and the scale of objects in the image (large focal length --> small field of
+   view angle).
+   - In a physical camera, it is the distance (in meters) between the center of
+     the lens and the plane at which all incoming, parallel light rays converge
+     (assuming a radially symmetric lens).
+   - in the pinhole model, `(f_x, f_y)` is described as "focal length", but the
+     units are in pixels and the interpretation is different. The relationship
+     between `(f_x, f_y)` and the physical focal length `F` is `f_i = F * s_i`,
+     where `(s_x, s_y)` are the number of pixels per meter in the x- and
+     y-directions (of the image). Both values described as "focal length" have
+     analogous effects on field of view and scale of objects in the image.
+ - __frame__: (Also "pose") an origin point and a space-spanning basis in 2D/3D,
+   as in @ref multibody_frames_and_bodies.
+   - Incidentally, the word "frame" is also used in conjunction with a single
+   image in a video (such as a "video frame"). Drake doesn't use this sense in
+   discussing cameras (unless explicitly noted).
+ - __image__: an array of measurements such that the measured values have
+   spatial relationships based on where they are in the array.
+ - __image frame__: the 2D frame embedded in 3D space spanning the image plane.
+   The image frame's x- and y-axes are parallel with `Cx` and `Cy`,
+   respectively. Coordinates are expressed as the pair `(u, v)` and the camera's
+   image lies on the plane spanned by the frame's basis, entirely in the first
+   quadrant (i.e, `u ≥ 0` and `v ≥ 0`).
+ - __image plane__: a plane in 3D which is perpendicular to the camera's viewing
+   direction. Conceptually, the image lies on this plane.
+     - In a physical pinhole camera, the aperture is between the image plane and
+     the environment being imaged.
+     - In the pinhole model, the image plane lies between the environment and
+     aperture (i.e., in the positive Cz direction from Co).
+ - __imager__: a sensor whose measurements are reported in images.
+ - __principal point__: The projection of the camera origin, `Co`, on the image
+   plane. Its value is measured from the image's origin in pixels.
+ - __sensor__: a measurement device.
+ - __viewing direction__: the direction the camera is facing. Defined as being
+   parallel with Cz.
+
+ When looking at the resulting image and reasoning about the camera that
+ produced it, one can say that Cz points into the image, Cx is parallel with the
+ image rows, pointing to the right, and Cy is parallel with the image columns,
+ pointing down leading to language such as: "X-right", "Y-down", and "Z-forward".
 */
 class CameraInfo final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CameraInfo)
 
   /**
-   Constructor that directly sets the image size, center, and focal lengths.
+   Constructor that directly sets the image size, principal point, and focal
+   lengths.
 
-   @param width The image width in pixels, must be greater than zero.
-   @param height The image height in pixels, must be greater than zero.
-   @param focal_x The focal length x in pixels.
-   @param focal_y The focal length y in pixels.
-   @param center_x The x coordinate of the principal point in pixels.
-   @param center_y The y coordinate of the principal point in pixels.
+   @param width    The image width in pixels, must be greater than zero.
+   @param height   The image height in pixels, must be greater than zero.
+   @param focal_x  The _model_ "focal length" x in pixels (as documented above).
+   @param focal_y  The _model_ "focal length" y in pixels (as documented above).
+   @param center_x The x coordinate of the principal point in pixels (as
+                   documented above).
+   @param center_y The y coordinate of the principal point in pixels (as
+                   documented above).
   */
   CameraInfo(int width, int height, double focal_x, double focal_y,
              double center_x, double center_y);
 
   /**
-   Constructor that sets the image size and vertical field of view `fov_y`.
-   We assume there is no image offset, so the image center `(center_x,`
-   `center_y)` is equal to `(width / 2, height / 2)`.  We also assume the
-   focal lengths `focal_x` and `focal_y` are identical.  The horizontal
-   field of view `fov_x` is calculated using the aspect ratio of the image
-   width and height together with the vertical field of view:
-   <pre>
-     fov_x = 2 * atan(width / height * tan(fov_y / 2)).
-   </pre>
-   This can be derived from the equations of the focal lengths:
-   <pre>
-     focal_x = width / 2 / tan(fov_x / 2)
-     focal_y = height / 2 / tan(fov_y / 2)
-   </pre>
-   where `focal_x / focal_y = 1`.
+   Constructs this instance from image size and vertical field of view. We
+   assume the principal point is in the center of the image;
+   `(center x, center_y)` is equal to `(width / 2, height / 2)`. We also assume
+   the focal lengths `focal_x` and `focal_y` are identical (modeling a radially
+   symmetric lens). The value is derived from field of view and image
+   size as:
+
+        focal_x = focal_y = height * 0.5 / tan(0.5 * fov_y)
 
    @param width The image width in pixels, must be greater than zero.
    @param height The image height in pixels, must be greater than zero.
-   @param fov_y The vertical field of view.
+   @param fov_y The vertical field of view in radians.
   */
   CameraInfo(int width, int height, double fov_y);
 
@@ -126,7 +184,7 @@ class CameraInfo final {
   /** Returns the principal point's y coordinate in pixels. */
   double center_y() const { return intrinsic_matrix_(1, 2); }
 
-  /** Returns the camera intrinsic matrix. */
+  /** Returns the camera intrinsic matrix, K. */
   const Eigen::Matrix3d& intrinsic_matrix() const {
     return intrinsic_matrix_;
   }

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -17,38 +17,52 @@ and camera intrinsic parameters.
 Please note the following terms:
 
 - frame, pose: denotes an origin and a space-spanning basis in 2D/3D, as in
-  @ref multibody_frames_and_bodies.
-- video frame: an image in a video sequence.
-- camera: an image sensor with lens; in Drake, this will be modeled as a
-  pinhole cameras unless stated otherwise. Because of this, the camera
-  aperature is a point in space.
-- image plane: defines how the 3D world is projected to a 2D image.
+  @ref multibody_frames_and_bodies. Unless otherwise stated, any described
+  frame implies this definition.
+- video frame: an image in a video sequence. This is *not* an extension of
+  "frame" as a general term.
+- sensor: a device used to take and report measurements.
+- image: an array of measurements. Coordinates are in pixels.
+- imager: a sensor that measures images.
+- camera: an image sensor.
+- aperature: a hole through which light travels through.
+- image plane: defines how the 3D world is projected to a 2D image. In
+  accordance with the OpenCV documentation below, the image plane will be
+  presented as though it were "in front" of the aperature, rather than behind
+  (which requires accounting for the camera obscura effect).
+- pinhole camera: a physical camera with no lens and a tiny aperature.
+- pinhole model: modeling a camera as though it were a pinhole camera, with
+  parameters that account for the camera lens and image plane. In Drake, all
+  cameras are assumed to use the pinhole model unless otherwise stated. The
+  images captured by these cameras are 2D, and their pixel coordinates are
+  described as `(u, v)`.
+- viewing direction / optical axis: direction from aperature towards scene being
+  captured by the camera (orthogonal to the image plane for the pinhole model).
+- principal point, camera center: the intersection of the viewing ray with the
+  image plane, typically measured in pixels.
 
-The camera frame `C` is comprised of the basis [Cx Cy Cz] and origin point Co,
+The camera frame C is comprised of the basis [Cx Cy Cz] and origin point Co,
 which are described as follows:
 
-- Co at camera aperature.
-- Cz aligned with the viewing direction, orthogonal to the image plane.
-- Cx aligned with the right direction of the image plane.
-- Cy aligned with the downwards direction of the image plane.
+- Co at camera aperature (per the pinhole model)
+- Cz aligned with the optical axis (orthogonal to the image plane).
+- Cx aligned with the `u` axis of the captured image.
+- Cy aligned with the `v` axis of the captured image.
 
 This can be summarized as `X-right`, `Y-down`, and `Z-forward` with respect to
-the image plane.
+the image plane / captured image when visualized in 3D w.r.t. the camera frame.
 
-The image plane can be described in the following coordinate systems:
-
-- normalized coordinate system `(X/Z, Y/Z)`, with its origin at the principal
-  point.
-- pixel coordinate system `(u, v)` using the following transformation:
-  <pre>
-    u = focal_x * (X/Z) + center_x
-    v = focal_y * (Y/Z) + center_y
-  </pre>
-  where `focal_x, focal_y` are focal lengths, and `center_x, center_y` describe
-  the principal point.
+The projection from coordinates `(X, Y, Z)`, in meters `m`, in the camera frame
+C to image coordinates `(u, v)`, in pixels, can be described as:
+<pre>
+  u = focal_x * (X/Z) + center_x
+  v = focal_y * (Y/Z) + center_y
+</pre>
+where `focal_x, focal_y` are the focal lengths, in `pixels / (m / m)`, and
+`center_x, center_y`, in pixels, describe the camera center (or principal
+point).
 
 For more detail including an explanation of the focal lengths, refer to:
-- https://en.wikipedia.org/wiki/Pinhole_camera_model
 - http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
 */
 class CameraInfo final {

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -62,14 +62,14 @@ namespace sensors {
  - (f_x, f_y) defines the model focal length.
 
  In other words, for point Q in the world frame, its texture coordinates
- `(u_q, v_q)` are calculated as:
+ `(u_Q, v_Q)` are calculated as:
 
-      │ u_q │
-     s│ v_q │ = K ⋅ X_CW ⋅ p_WQ
+      │ u_Q │
+     s│ v_Q │ = K ⋅ X_CW ⋅ p_WQ
       │  1  │
 
  Note: The expression on the right will generally produce a homogeneous
- coordinate vector of the form `(s * u_q, s * v_q, s)`. The texture coordinate
+ coordinate vector of the form `(s * u_Q, s * v_Q, s)`. The texture coordinate
  is defined as the first two measures when the *third* measure is 1. The magic
  of homogeneous coordinates allows us to simply factor out `s`.
 
@@ -150,10 +150,10 @@ class CameraInfo final {
   /**
    Constructs this instance from image size and vertical field of view. We
    assume the principal point is in the center of the image;
-   `(center x, center_y)` is equal to `(width / 2, height / 2)`. We also assume
-   the focal lengths `focal_x` and `focal_y` are identical (modeling a radially
-   symmetric lens). The value is derived from field of view and image
-   size as:
+   `(center x, center_y)` is equal to `(width / 2 - 0.5, height / 2 - 0.5)`. We
+   also assume the focal lengths `focal_x` and `focal_y` are identical
+   (modeling a radially symmetric lens). The value is derived from field of
+   view and image size as:
 
         focal_x = focal_y = height * 0.5 / tan(0.5 * fov_y)
 

--- a/systems/sensors/dev/rgbd_camera.h
+++ b/systems/sensors/dev/rgbd_camera.h
@@ -25,6 +25,10 @@ namespace dev {
 /** An RGB-D camera system that provides RGB, depth, and label images using
  the geometry in the geometry::dev::SceneGraph.
 
+ @warning This is an old interface, with potentially ambiguous and outdated
+ terms. Please see `RgbdSensor` and `CameraInfo` for more modern
+ terminology.
+
  @system{RgbdCamera,
     @input_port{geometry_query},
     @output_port{color_image}

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -29,7 +29,7 @@ using geometry::SceneGraph;
 using math::RigidTransformd;
 using std::move;
 
-RgbdSensor::RgbdSensor(std::string name, FrameId parent_frame,
+RgbdSensor::RgbdSensor(FrameId parent_frame,
                        const RigidTransformd& X_PB,
                        const DepthCameraProperties& properties,
                        bool show_window)
@@ -39,8 +39,6 @@ RgbdSensor::RgbdSensor(std::string name, FrameId parent_frame,
       depth_camera_info_(properties.width, properties.height, properties.fov_y),
       properties_(properties),
       X_PB_(X_PB) {
-  this->set_name(name);
-
   query_object_input_port_ = &this->DeclareAbstractInputPort(
       "geometry_query", Value<geometry::QueryObject<double>>{});
 

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -41,14 +41,15 @@ namespace sensors {
 
  This class uses the following frames:
 
-   - `W` - world frame
-   - `B` - sensor base frame, used as the attaching frame for `C` and `D`
-   - `C` - color camera frame, used for both color and label images
-   - `D` - depth camera frame
+   - W - world frame
+   - C - color camera frame, used for both color and label images
+   - D - depth camera frame
+   - B - sensor body frame, used common frame for C and D which can capture the
+     physical container of the sensor.
 
- By default, frames `B`, `C`, and `D` are coincident and aligned. These can be
- changed after construction by modifying `X_BC` and `X_BD`. `C` and `D` are
- always rigidly affixed to the sensor base frame `B`.
+ By default, frames B, C, and D are coincident and aligned. These can be
+ changed after construction by modifying `X_BC` and `X_BD`. Frames C and D are
+ always rigidly affixed to the sensor body frame B.
 
  <!-- TODO(gizatt): The setters for modifying the sensor poses create a
  vulnerability that allows users to modify internal system state during

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -37,7 +37,7 @@ namespace sensors {
  }
 
  The following text uses terminology and camera frame conventions from
- %CameraInfo. Please review its documentation.
+ CameraInfo. Please review its documentation.
 
  This class uses the following frames:
 

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -42,10 +42,14 @@ namespace sensors {
  This class uses the following frames:
 
    - W - world frame
-   - C - color camera frame, used for both color and label images
+   - C - color camera frame, used for both color and label cameras to guarantee
+     perfect registration between color and label images.
    - D - depth camera frame
-   - B - sensor body frame, used common frame for C and D which can capture the
-     physical container of the sensor.
+   - B - sensor body frame, approximately, the frame of the "physical" sensor
+     that contains the color, depth, and label cameras. The contained cameras
+     are rigidly fixed to B and X_WB is what is used to pose the sensor in the
+     world (or, alternatively, X_PB where P is some parent frame for which X_WP
+     is known).
 
  By default, frames B, C, and D are coincident and aligned. These can be
  changed after construction by modifying `X_BC` and `X_BD`. Frames C and D are

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -93,11 +93,6 @@ class RgbdSensor final : public LeafSystem<double> {
     math::RigidTransformd X_BD;
   };
 
-  // TODO(SeanCurtis-TRI): Seriously consider a OpenGL-style position-target-up
-  //  constructor for RgbdSensor -- it can work for either stationary or
-  //  generally affixed sensor as long as the position, target, and up vectors
-  //  are all defined w.r.t. the parent frame.
-
   /** Constructs an %RgbdSensor whose frame `B` is rigidly affixed to the frame
    P, indicated by `frame_id`, and with the given camera properties. The camera
    will move as frame P moves. For a stationary camera, use the frame id from
@@ -109,6 +104,10 @@ class RgbdSensor final : public LeafSystem<double> {
    @param X_PB           The pose of the camera `B` frame relative to the parent
                          frame `P`.
    @param properties     The properties which define this camera's intrinsics.
+                         Please note that this assumes that the color and depth
+                         cameras share the same intrinsics.
+   @param camera_poses   The pose the color and depth cameras with respect to
+                         the sensor base.
    @param show_window    A flag for showing a visible window. If this is false,
                          off-screen rendering is executed. The default is false.
    */
@@ -117,6 +116,9 @@ class RgbdSensor final : public LeafSystem<double> {
              const geometry::render::DepthCameraProperties& properties,
              const CameraPoses& camera_poses = {},
              bool show_window = false);
+
+  // TODO(eric.cousineau): Add a constructor that allows unique intrinsics for
+  // color and depth when the need arises.
 
   ~RgbdSensor() = default;
 
@@ -204,9 +206,8 @@ class RgbdSensor final : public LeafSystem<double> {
   const geometry::render::DepthCameraProperties properties_;
   // The position of the camera's B frame relative to its parent frame P.
   const math::RigidTransformd X_PB_;
-
+  // Camera poses.
   math::RigidTransformd X_BC_;
-
   math::RigidTransformd X_BD_;
 };
 
@@ -244,9 +245,6 @@ class RgbdSensorDiscrete final : public systems::Diagram<double> {
 
   /** Returns reference to RgbdSensor instance.  */
   const RgbdSensor& sensor() const { return *camera_; }
-
-  /** Returns mutable reference to RgbdSensor instance.  */
-  RgbdSensor& mutable_sensor() { return *camera_; }
 
   /** Returns update period for discrete camera.  */
   double period() const { return period_; }

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -149,6 +149,9 @@ class RgbdSensorTest : public ::testing::Test {
              << "The sensor's parent id (" << sensor_->parent_frame_id()
              << ") does not match the expected id (" << parent_id << ")";
     }
+    // TODO(eric.cousineau): Remove the name tests, as they don't make sense
+    // since no part of RgbdSensor part really needs it, and it's the System
+    // framework's responsibility.
     if (sensor_->get_name() != name) {
       return ::testing::AssertionFailure()
           << "The sensor's name '" << sensor_->get_name()


### PR DESCRIPTION
- Start trending towards using `CameraInfo`
- Add initial simplified terminology treatise
- Rename `Rgbd*` to `CameraArray`
- Get rid of default transform; I personally do not want it there, as I
feel it does more harm than good (adds too much noise)

WARNING: This will not compile. This is just an initial preview.
EDIT: To clarify, if there is high-level acceptance of this change, I will update it such that it passes CI.

This incorporates feedback from draft PR #11337, and will supersede it, per this comment:
https://github.com/RobotLocomotion/drake/pull/11337#issuecomment-505143200

This targets #11704.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seancurtis-tri/drake/5)
<!-- Reviewable:end -->
